### PR TITLE
Add TomDoc to factoids-core

### DIFF
--- a/src/factoids-core.coffee
+++ b/src/factoids-core.coffee
@@ -1,3 +1,6 @@
+# Description:
+#   Provides important functions used by the main Factoids code.
+
 class Factoids
   constructor: (@robot) ->
     if @robot.brain?.data?


### PR DESCRIPTION
Hubot tests every file for proper TomDoc comments at the top, regardless of whether a file might be for internal use only. Added a very simple TomDoc to get Hubot to be quiet.