### PR TITLE
Allow two-letter factoids (for short acronyms)

### DIFF
--- a/src/factoids.coffee
+++ b/src/factoids.coffee
@@ -33,7 +33,7 @@ module.exports = (robot) ->
 
   prefix = process.env.HUBOT_FACTOID_PREFIX or '!'
 
-  robot.hear new RegExp("^[#{prefix}]([\\w\\s-]{2,}\\w)( @.+)?", 'i'), (msg) =>
+  robot.hear new RegExp("^[#{prefix}]([\\w\\s-]{1,}\\w)( @.+)?", 'i'), (msg) =>
     fact = @factoids.get msg.match[1]
     to = msg.match[2]
     if not fact? or fact.forgotten
@@ -43,7 +43,7 @@ module.exports = (robot) ->
       to ?= msg.message.user.name
       msg.send "#{to.trim()}: #{fact.value}"
 
-  robot.respond new RegExp("[#{prefix}]([\\w\\s-]{2,}\\w)", 'i'), (msg) =>
+  robot.respond new RegExp("[#{prefix}]([\\w\\s-]{1,}\\w)", 'i'), (msg) =>
     fact = @factoids.get msg.match[1]
     if not fact? or fact.forgotten
       msg.reply "Not a factoid"
@@ -51,14 +51,14 @@ module.exports = (robot) ->
       fact.popularity++
       msg.send "#{fact.value}"
 
-  robot.respond /learn (.{3,}) = ([^@].+)/i, (msg) =>
+  robot.respond /learn (.{2,}) = ([^@].+)/i, (msg) =>
     [key, value] = [msg.match[1], msg.match[2]]
     factoid = @factoids.set key, value, msg.message.user.name
 
     if factoid.value?
       msg.reply "OK, #{key} is now #{factoid.value}"
 
-  robot.respond /learn (.{3,}) =~ s\/(.+)\/(.+)\/(.*)/i, (msg) =>
+  robot.respond /learn (.{2,}) =~ s\/(.+)\/(.+)\/(.*)/i, (msg) =>
     key = msg.match[1]
     re = new RegExp(msg.match[2], msg.match[4])
     fact = @factoids.get key
@@ -71,13 +71,13 @@ module.exports = (robot) ->
     else
       msg.reply 'Not a factoid'
 
-  robot.respond /forget (.{3,})/i, (msg) =>
+  robot.respond /forget (.{2,})/i, (msg) =>
     if @factoids.forget msg.match[1]
       msg.reply "OK, forgot #{msg.match[1]}"
     else
       msg.reply 'Not a factoid'
 
-  robot.respond /remember (.{3,})/i, (msg) =>
+  robot.respond /remember (.{2,})/i, (msg) =>
     factoid = @factoids.remember msg.match[1]
     if factoid? and not factoid.forgotten
       msg.reply "OK, #{msg.match[1]} is #{factoid.value}"
@@ -88,7 +88,7 @@ module.exports = (robot) ->
     url = process.env.HUBOT_BASE_URL or "http://not-yet-set/"
     msg.reply "#{url.replace /\/$/, ''}/#{robot.name}/factoids"
 
-  robot.respond /search (.{3,})/i, (msg) =>
+  robot.respond /search (.{2,})/i, (msg) =>
     factoids = @factoids.search msg.match[1]
 
     if factoids.length > 0
@@ -97,13 +97,13 @@ module.exports = (robot) ->
     else
       msg.reply 'No factoids matched'
 
-  robot.respond /alias (.{3,}) = (.{3,})/i, (msg) =>
+  robot.respond /alias (.{2,}) = (.{2,})/i, (msg) =>
     who = msg.message.user.name
     alias = msg.match[1]
     target = msg.match[2]
     msg.reply "OK, aliased #{alias} to #{target}" if @factoids.set msg.match[1], "@#{msg.match[2]}", msg.message.user.name, false
 
-  robot.respond /drop (.{3,})/i, (msg) =>
+  robot.respond /drop (.{2,})/i, (msg) =>
     user = msg.envelope.user
     isAdmin = robot.auth?.hasRole(user, 'factoids-admin') or robot.auth?.hasRole(user, 'admin')
     if isAdmin or not robot.auth?


### PR DESCRIPTION
Oh, hello! I don't suppose the 3-letter minimum could be removed so that our org can still use factoids for all the short 2-letter acronyms we need to keep track of :) Thanks!